### PR TITLE
fix: should pass the imageType

### DIFF
--- a/lib/src/web_image_downloader.dart
+++ b/lib/src/web_image_downloader.dart
@@ -24,6 +24,7 @@ class WebImageDownloader {
         uInt8List: res.bodyBytes,
         imageQuality: imageQuality,
         name: name,
+        imageType: imageType,
       );
     } else {
       throw Exception(res.statusCode);


### PR DESCRIPTION
When call `downloadImageFromUInt8List` from `downloadImageFromWeb` should pass the argument `imageType`.